### PR TITLE
Feature/add connection status

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/forensic-logging-client",
-  "version": "5.2.0",
+  "version": "6.2.0",
   "description": "Client for connecting to forensic-logging-sidecar",
   "main": "src/index.js",
   "author": "ModusBox",

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,14 @@ class Sidecar extends EventEmitter {
     })
   }
 
+  isConnected () {
+    if (!this._connected) {
+      return false
+    }
+
+    return true
+  }
+
   write (msg) {
     if (!this._connected) {
       throw new Error('Sidecar is not connected')

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -64,6 +64,36 @@ Test('SidecarClient', sidecarClientTest => {
     createTest.end()
   })
 
+  sidecarClientTest.test('isConnected should', isConnectedTest => {
+    isConnectedTest.test('return true when the client is connected', test => {
+      // Arrange
+      let client = SidecarClient.create()
+      client._connected = true
+      client._socket = { write: sandbox.stub() }
+
+      // Act
+      const result = client.isConnected()
+
+      // Assert
+      test.equal(result, true, 'The client is connected')
+      test.end()
+    })
+
+    isConnectedTest.test('return false when the client is connected', test => {
+      // Arrange
+      let client = SidecarClient.create()
+
+      // Act
+      const result = client.isConnected()
+
+      // Assert
+      test.equal(result, false, 'The client is not connected')
+      test.end()
+    })
+
+    isConnectedTest.end()
+  })
+
   sidecarClientTest.test('connect should', connectTest => {
     connectTest.test('create socket connection and resolve when open', test => {
       let service = 'test'


### PR DESCRIPTION
Add a new `isConnected` function to the sidecar logging client, that reports on the current connection status.

This is required for https://github.com/mojaloop/project/issues/796 - in order to report on the connection status of the sidecar from the api.

Also bumped version to `6.2.0`